### PR TITLE
Update how devToolsExtension is added as per documentation

### DIFF
--- a/src/client/makeStore.dev.js
+++ b/src/client/makeStore.dev.js
@@ -1,4 +1,4 @@
-import {applyMiddleware, compose} from 'redux';
+import {createStore, applyMiddleware, compose} from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import optimisticMiddleware from '../universal/redux/middleware/optimisticMiddleware';
 import {syncHistory, routeReducer} from 'redux-simple-router'
@@ -17,8 +17,9 @@ const loggerMiddleware = createLogger({
 export default function (initialState) {
   const reduxRouterMiddleware = syncHistory(browserHistory)
   const createStoreWithMiddleware = compose(
-    applyMiddleware(reduxRouterMiddleware, optimisticMiddleware, thunkMiddleware, loggerMiddleware)
-  )(storeCreator);
+    applyMiddleware(reduxRouterMiddleware, optimisticMiddleware, thunkMiddleware, loggerMiddleware),
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  )(createStore);
 
   const store = createStoreWithMiddleware(makeReducer(), initialState);
   reduxRouterMiddleware.listenForReplays(store, state => ensureState(state).get('routing'));

--- a/src/client/storeCreator.js
+++ b/src/client/storeCreator.js
@@ -1,6 +1,0 @@
-import {createStore} from 'redux';
-
-export default () =>
-  window.devToolsExtension
-    ? window.devToolsExtension()(createStore)
-    : createStore;


### PR DESCRIPTION
Following the lead in the [redux-devtools-extension Docs](https://github.com/zalmoxisus/redux-devtools-extension) and the [react-redux-universal-hot-example createStore](https://github.com/erikras/react-redux-universal-hot-example/blob/master/src/redux/create.js) function, the app is loading again. I'm pretty new to this repo and redux, so I may not have the correct approach here. I just dug until I found a fix for the issue I was facing in #25. 

I really love what's going on with the Meatier project and am excited to see it keep moving forward!