### PR TITLE
fix/simplify redux-devtools-extension integration

### DIFF
--- a/src/client/makeStore.dev.js
+++ b/src/client/makeStore.dev.js
@@ -1,4 +1,4 @@
-import {applyMiddleware, compose} from 'redux';
+import {createStore, applyMiddleware, compose} from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import optimisticMiddleware from '../universal/redux/middleware/optimisticMiddleware';
 import {syncHistory, routeReducer} from 'redux-simple-router'
@@ -7,7 +7,6 @@ import makeReducer from '../universal/redux/makeReducer';
 import {ensureState} from 'redux-optimistic-ui';
 
 import createLogger from 'redux-logger';
-import storeCreator from './storeCreator';
 
 const loggerMiddleware = createLogger({
   level: 'info',
@@ -17,8 +16,9 @@ const loggerMiddleware = createLogger({
 export default function (initialState) {
   const reduxRouterMiddleware = syncHistory(browserHistory)
   const createStoreWithMiddleware = compose(
-    applyMiddleware(reduxRouterMiddleware, optimisticMiddleware, thunkMiddleware, loggerMiddleware)
-  )(storeCreator);
+    applyMiddleware(reduxRouterMiddleware, optimisticMiddleware, thunkMiddleware, loggerMiddleware),
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  )(createStore);
 
   const store = createStoreWithMiddleware(makeReducer(), initialState);
   reduxRouterMiddleware.listenForReplays(store, state => ensureState(state).get('routing'));


### PR DESCRIPTION
- enable the redux devtools-extension check in makeStore.dev
- remove storeCreator and simply use createStore from redux directly in makeStore.prod too