### PR TITLE
fix/simplify redux-devtools-extension integration

### DIFF
--- a/src/client/makeStore.dev.js
+++ b/src/client/makeStore.dev.js
@@ -1,4 +1,4 @@
-import {applyMiddleware, compose} from 'redux';
+import {createStore, applyMiddleware, compose} from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import optimisticMiddleware from '../universal/redux/middleware/optimisticMiddleware';
 import {syncHistory, routeReducer} from 'redux-simple-router'
@@ -7,7 +7,6 @@ import makeReducer from '../universal/redux/makeReducer';
 import {ensureState} from 'redux-optimistic-ui';
 
 import createLogger from 'redux-logger';
-import storeCreator from './storeCreator';
 
 const loggerMiddleware = createLogger({
   level: 'info',
@@ -17,8 +16,9 @@ const loggerMiddleware = createLogger({
 export default function (initialState) {
   const reduxRouterMiddleware = syncHistory(browserHistory)
   const createStoreWithMiddleware = compose(
-    applyMiddleware(reduxRouterMiddleware, optimisticMiddleware, thunkMiddleware, loggerMiddleware)
-  )(storeCreator);
+    applyMiddleware(reduxRouterMiddleware, optimisticMiddleware, thunkMiddleware, loggerMiddleware),
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  )(createStore);
 
   const store = createStoreWithMiddleware(makeReducer(), initialState);
   reduxRouterMiddleware.listenForReplays(store, state => ensureState(state).get('routing'));

--- a/src/client/makeStore.prod.js
+++ b/src/client/makeStore.prod.js
@@ -1,10 +1,9 @@
-import {applyMiddleware, compose} from 'redux';
+import {createStore, applyMiddleware, compose} from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import optimisticMiddleware from '../universal/redux/middleware/optimisticMiddleware';
 import {syncHistory, routeReducer} from 'redux-simple-router';
 import {browserHistory} from 'react-router';
 import makeReducer from '../universal/redux/makeReducer';
-import storeCreator from './storeCreator';
 
 export default function (initialState) {
   const reduxRouterMiddleware = syncHistory(browserHistory);
@@ -12,6 +11,6 @@ export default function (initialState) {
     reduxRouterMiddleware,
     optimisticMiddleware,
     thunkMiddleware
-  )(storeCreator);
+  )(createStore);
   return createStoreWithMiddleware(makeReducer(), initialState);
 }

--- a/src/client/storeCreator.js
+++ b/src/client/storeCreator.js
@@ -1,6 +1,0 @@
-import {createStore} from 'redux';
-
-export default () =>
-  window.devToolsExtension
-    ? window.devToolsExtension()(createStore)
-    : createStore;

--- a/src/universal/components/App/App.js
+++ b/src/universal/components/App/App.js
@@ -3,7 +3,7 @@ import styles from './App.css';
 
 export default class App extends Component {
   render() {
-    const maxWidth = __PRODUCTION__ ? '100%' : '1000px';
+    const maxWidth = __PRODUCTION__ ? '100%' : '100%';
     return (
       <div className={styles.app} style={{maxWidth}}>
         {this.props.children}


### PR DESCRIPTION
- enable the redux devtools-extension check in makeStore.dev
- remove storeCreator and simply use createStore from redux directly in makeStore.prod too
- and return some screen real estate in universal App component too in dev mode, left it configurable