### PR TITLE
Date.now() instead of new Date() for createdAt

### DIFF
--- a/src/server/graphql/models/Lanes/laneMutation.js
+++ b/src/server/graphql/models/Lanes/laneMutation.js
@@ -13,7 +13,7 @@ export default {
     },
     async resolve(source, {lane}, {rootValue}) {
       isLoggedIn(rootValue);
-      lane.createdAt = new Date();
+      lane.createdAt = Date.now();
       const newLane = await r.table('lanes').insert(lane, {returnChanges: true});
       if (newLane.errors) {
         throw errorObj({_error: 'Could not add lane'});

--- a/src/server/graphql/models/Notes/noteMutation.js
+++ b/src/server/graphql/models/Notes/noteMutation.js
@@ -12,7 +12,7 @@ export default {
     },
     async resolve(source, {note}, {rootValue}) {
       isLoggedIn(rootValue);
-      note.createdAt = new Date();
+      note.createdAt = Date.now();
       const newNote = await r.table('notes').insert(note, {returnChanges: true});
       if (newNote.errors) {
         throw errorObj({_error: 'Could not add note'});


### PR DESCRIPTION
when inserting lanes and notes on mutations, use Date.now() for
createdAt propery instead of Date object , on node 5.6.0 was logging
graphQL type errors probably because of object type, but it is just a
guess