### PR TITLE
components are much more efficient with pureRender

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "piping": "0.3.0",
     "query-string": "3.0.0",
     "react": "^0.14.7",
+    "react-addons-shallow-compare": "0.14.7",
     "react-dnd": "2.0.2",
     "react-dnd-html5-backend": "2.0.2",
     "react-dom": "0.14.6",

--- a/src/client/Root.js
+++ b/src/client/Root.js
@@ -1,8 +1,10 @@
 import React, {Component} from 'react';
+import pureRender from '../universal/decorators/pureRender/pureRender';
 import {Router, browserHistory} from 'react-router';
 import {Provider} from 'react-redux';
 import routes from '../universal/routes/index';
 
+@pureRender
 export default class Root extends Component {
   static propTypes = {
     store: React.PropTypes.object.isRequired

--- a/src/universal/components/App/App.js
+++ b/src/universal/components/App/App.js
@@ -1,6 +1,8 @@
 import React, { PropTypes, Component } from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import styles from './App.css';
 
+@pureRender
 export default class App extends Component {
   render() {
     const maxWidth = __PRODUCTION__ ? '100%' : '1000px';

--- a/src/universal/components/Footer/Footer.js
+++ b/src/universal/components/Footer/Footer.js
@@ -1,7 +1,9 @@
 import React, { PropTypes, Component } from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import styles from './Footer.css';
 import {Link} from 'react-router';
 
+@pureRender
 export default class Footer extends Component {
 
   render() {

--- a/src/universal/components/Navigation/Navigation.js
+++ b/src/universal/components/Navigation/Navigation.js
@@ -3,10 +3,12 @@ import RaisedButton from 'material-ui/lib/raised-button';
 import AppBar from 'material-ui/lib/app-bar';
 import Paper from 'material-ui/lib/paper';
 import React, { PropTypes, Component } from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import styles from './Navigation.css';
 import {Link} from 'react-router';
 import smallLogo from './../Navigation/logo-small.png';
 
+@pureRender
 export default class Navigation extends Component {
   static propTypes = {
     isAuthenticated: PropTypes.bool.isRequired

--- a/src/universal/components/NotFound/NotFound.js
+++ b/src/universal/components/NotFound/NotFound.js
@@ -1,5 +1,7 @@
 import React, {Component} from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 
+@pureRender
 export default class NotFound extends Component {
   render() {
     return (

--- a/src/universal/containers/App/AppContainer.js
+++ b/src/universal/containers/App/AppContainer.js
@@ -1,4 +1,5 @@
 import React, { PropTypes, Component } from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import App from '../../components/App/App';
 import injectTapeEventPlugin from 'react-tap-event-plugin';
 import { bindActionCreators } from 'redux';
@@ -10,6 +11,7 @@ import {ensureState} from 'redux-optimistic-ui';
 injectTapeEventPlugin();
 @connect(mapStateToProps)
 @loginWithToken(socketOptions.authTokenName)
+@pureRender
 export default class AppContainer extends Component {
   static propTypes = {
     children: PropTypes.element.isRequired,

--- a/src/universal/decorators/pureRender/pureRender.js
+++ b/src/universal/decorators/pureRender/pureRender.js
@@ -1,0 +1,7 @@
+import shallowCompare from 'react-addons-shallow-compare';
+
+export default function pureRenderDecorator(target) {
+  target.prototype.shouldComponentUpdate = function (nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+}

--- a/src/universal/modules/kanban/components/Kanban/Kanban.js
+++ b/src/universal/modules/kanban/components/Kanban/Kanban.js
@@ -1,8 +1,10 @@
 import React, { Component, PropTypes } from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import Lanes from '../Lanes/Lanes.js';
 import styles from './Kanban.css';
 import uuid from 'node-uuid';
 
+@pureRender
 export default class Kanban extends Component {
   static propTypes = {
     laneActions: PropTypes.object.isRequired,

--- a/src/universal/modules/kanban/components/Lane/Lane.js
+++ b/src/universal/modules/kanban/components/Lane/Lane.js
@@ -1,10 +1,12 @@
 import React, {Component, PropTypes} from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import EditableContainer from '../../containers/Editable/EditableContainer.js';
 import Notes from '../Notes/Notes';
 import styles from './lane.css';
 import uuid from 'node-uuid';
 import {getFormState} from 'universal/redux/helpers';
 
+@pureRender
 export default class Lane extends Component {
   static propTypes = {
     laneActions: PropTypes.object.isRequired,

--- a/src/universal/modules/kanban/components/Lanes/Lanes.js
+++ b/src/universal/modules/kanban/components/Lanes/Lanes.js
@@ -1,6 +1,8 @@
 import React, {Component, PropTypes} from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import LaneContainer from '../../containers/Lane/LaneContainer.js';
 
+@pureRender
 export default class Lanes extends Component {
   static propTypes = {
     laneActions: PropTypes.object.isRequired,

--- a/src/universal/modules/kanban/components/Note/Note.js
+++ b/src/universal/modules/kanban/components/Note/Note.js
@@ -1,4 +1,5 @@
 import React, {Component, PropTypes} from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import {DragSource, DropTarget} from 'react-dnd';
 import { findDOMNode } from 'react-dom';
 import {NOTE} from 'universal/modules/kanban/ducks/notes';
@@ -75,6 +76,7 @@ const noteTarget = {
 @DropTarget(NOTE, noteTarget, (connect) => ({
   connectDropTarget: connect.dropTarget()
 }))
+@pureRender
 export default class Note extends React.Component {
   render() {
     const {connectDragSource, connectDropTarget, isDragging, ...props} = this.props;

--- a/src/universal/modules/kanban/components/Notes/Notes.js
+++ b/src/universal/modules/kanban/components/Notes/Notes.js
@@ -1,4 +1,5 @@
 import React, {Component, PropTypes} from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import EditableContainer from '../../containers/Editable/EditableContainer.js';
 import {NOTE} from 'universal/modules/kanban/ducks/notes';
 import {DropTarget} from 'react-dnd';
@@ -24,6 +25,7 @@ const noteTarget = {
   connectDropTarget: connect.dropTarget()
 }))
 
+@pureRender
 export default class Notes extends Component {
 
   render() {

--- a/src/universal/modules/kanban/containers/Editable/EditableContainer.js
+++ b/src/universal/modules/kanban/containers/Editable/EditableContainer.js
@@ -1,9 +1,11 @@
 import React, {PropTypes, Component} from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import {reduxForm} from 'redux-form';
 import Joi from 'joi';
 import Editable from 'universal/modules/kanban/components/Editable/Editable';
 import {getFormState} from 'universal/redux/helpers';
 
+@pureRender
 @reduxForm({getFormState})
 export default class EditableContainer extends Component {
   static PropTypes = {

--- a/src/universal/modules/kanban/containers/Kanban/KanbanContainer.js
+++ b/src/universal/modules/kanban/containers/Kanban/KanbanContainer.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { DragDropContext } from 'react-dnd';
@@ -11,6 +12,7 @@ import {loadNotes} from 'universal/modules/kanban/ducks/notes';
 import {ensureState} from 'redux-optimistic-ui';
 import requireAuth from 'universal/decorators/requireAuth/requireAuth';
 
+@pureRender
 @connect(mapStateToProps, mapDispatchToProps)
 @requireAuth
 @reduxSocket(socketOptions)

--- a/src/universal/modules/kanban/containers/Lane/LaneContainer.js
+++ b/src/universal/modules/kanban/containers/Lane/LaneContainer.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import {noteActions} from 'universal/modules/kanban/ducks/notes.js';
@@ -6,6 +7,7 @@ import Lane from 'universal/modules/kanban/components/Lane/Lane';
 import {List} from 'immutable';
 import {ensureState} from 'redux-optimistic-ui';
 
+@pureRender
 @connect(mapStateToProps, mapDispatchToProps)
 export default class LaneContainer extends Component {
   static propTypes = {

--- a/src/universal/modules/landing/components/Header/Header.js
+++ b/src/universal/modules/landing/components/Header/Header.js
@@ -1,8 +1,10 @@
 import React, { Component, PropTypes } from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import styles from './Header.css';
 import {Link} from 'react-router';
 import RaisedButton from 'material-ui/lib/raised-button';
 
+@pureRender
 export default class Header extends Component {
   render() {
     return (

--- a/src/universal/modules/landing/components/Home/Home.js
+++ b/src/universal/modules/landing/components/Home/Home.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import Header from '../Header/Header';
 
+@pureRender
 export default class Home extends Component {
   render() {
     return (

--- a/src/universal/modules/landing/components/Landing/Landing.js
+++ b/src/universal/modules/landing/components/Landing/Landing.js
@@ -1,9 +1,11 @@
 import React, { PropTypes, Component } from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import styles from './Landing.css';
 
 import Footer from 'universal/components/Footer/Footer';
 import Navigation from 'universal/components/Navigation/Navigation';
 
+@pureRender
 export default class Landing extends Component {
   static propTypes = {
     children: PropTypes.element.isRequired,

--- a/src/universal/modules/landing/containers/Landing/LandingContainer.js
+++ b/src/universal/modules/landing/containers/Landing/LandingContainer.js
@@ -1,8 +1,10 @@
 import React, {PropTypes, Component} from 'react';
+import pureRender from 'universal/decorators/pureRender/pureRender';
 import Landing from 'universal/modules/landing/components/Landing/Landing';
 import {connect} from 'react-redux';
 import {ensureState} from 'redux-optimistic-ui';
 
+@pureRender
 @connect(mapStateToProps)
 export default class LandingContainer extends Component {
   static propTypes = {


### PR DESCRIPTION
In mucking about profiling this code (don't ask) I noticed that there are a lot of unnecessary renders.

This is a tiny little decorator that does the same as the [PureRenderMixin](https://facebook.github.io/react/docs/pure-render-mixin.html) using [Shallow Compare](https://facebook.github.io/react/docs/shallow-compare.html)