### PR TITLE
resolve promises in parallel

### DIFF
--- a/src/server/database/setupDB.js
+++ b/src/server/database/setupDB.js
@@ -10,17 +10,25 @@ const database = [
 ];
 
 export default async function setupDB() {
-  for (let db of databases) {
-    try {
-      await r.dbCreate(db);
-    } catch (e) {
-    }
-    let indices = [];
-    const tables = await r.db(db).tableList().run();
-    await Promise.all(tables.map(table => r.db(db).tableDrop(table)));
-    await Promise.all(database.map(table => r.db(db).tableCreate(table.name)));
-    database.forEach(table => table.indices.forEach(index => indices.push(r.db(db).table(table.name).indexCreate(index))));
-    await Promise.all(indices);
-  }
+  await Promise.all(databases.map(reset));
   await r.getPool().drain();
+}
+
+async function reset(db) {
+  try {
+    console.log('creating', db);
+    await r.dbCreate(db);
+  } catch (e) {
+    console.log(e && e.message);
+  }
+  const indices = [];
+  const tables = await r.db(db).tableList().run();
+  console.log('dropping all tables on', db);
+  await Promise.all(tables.map(table => r.db(db).tableDrop(table)));
+  console.log('creating new tables on', db);
+  await Promise.all(database.map(table => r.db(db).tableCreate(table.name)));
+  console.log('adding indexes to tables on', db);
+  database.forEach(table => table.indices.forEach(index => indices.push(r.db(db).table(table.name).indexCreate(index))));
+  await Promise.all(indices);
+  console.log('set up', db);
 }

--- a/src/universal/utils/promises.js
+++ b/src/universal/utils/promises.js
@@ -1,8 +1,6 @@
 export async function resolvePromiseMap(promiseMap) {
-  let importMap = new Map();
-  for (var [key, promise] of promiseMap) {
-    let value = await promise;
-    importMap.set(key, value)
-  }
-  return importMap;
+  const keys = Array.from(promiseMap.keys());
+  const promises = Array.from(promiseMap.values());
+  const values = await Promise.all(promises);
+  return new Map(values.map((value, i) => [keys[i], value]));
 }


### PR DESCRIPTION
This dispatches all promiseMap resolutions in parallel then uses `Promise.all()` to await all values.

Can split from parallel resolution of setupDB if desired.