### PR TITLE
Change loop to fix creation of indices on database setup

### DIFF
--- a/src/server/database/setupDB.js
+++ b/src/server/database/setupDB.js
@@ -35,14 +35,14 @@ async function reset({db, isUpdate}) {
   }));
   console.log(`>>Adding table indices on: ${db}`);
   const indices = [];
-  database.forEach(async (table) => {
-    const indexList = await r.db(db).table(table).indexList();
+  for (let table of database) {
+    const indexList = await r.db(db).table(table.name).indexList();
     table.indices.forEach(index => {
       if (indexList.indexOf(index) === -1) {
         indices.push(r.db(db).table(table.name).indexCreate(index))
       }
     })
-  });
+  }
   await Promise.all(indices);
   console.log(`>>Setup complete for: ${db}`);
 }


### PR DESCRIPTION
`indices` is not populated before `Promise.all(indices)` is called because the indexList promise does not seem to be resolved sequentially. Changing to a for...of loop seems to fix the issue. 

Also referenced the name property on the table object instead of just the object itself when creating the `indexList`