### PR TITLE
prepend doctype on server render

### DIFF
--- a/src/server/createSSR.js
+++ b/src/server/createSSR.js
@@ -23,6 +23,7 @@ function renderApp(res, store, assets, renderProps) {
     assets={assets}
     renderProps={renderProps}
     />);
+  res.write('<!DOCTYPE html>');
   htmlStream.pipe(res, {end: false});
   htmlStream.on('end', () => res.end());
 }


### PR DESCRIPTION
I'd prefer to avoid additional dependencies if possible.

Fixes #126 and closes #127.