### PR TITLE
cache compiled fingerprinted assets for 1y

### DIFF
--- a/src/server/worker.js
+++ b/src/server/worker.js
@@ -43,7 +43,11 @@ export function run(worker) {
   });
   if (PROD) {
     app.use(compression());
-    app.use('/static', express.static('build'));
+    const volatile = ['prerender.js', 'prerender.css', 'assets.json'];
+    for (let i = volatile.length; i--;) {
+      app.use(`/static/${volatile[i]}`, express.static(`build/${volatile[i]}`));
+    }
+    app.use('/static', express.static('build', {maxAge: '1y'}));
   }
 
   // Oauth


### PR DESCRIPTION
This sets the Cache-Control header to instruct the browser to cache everything served from the build folder for one year except for the three files marked volatile.