### PR TITLE
create meatierForm to cut down on boilerplate

### DIFF
--- a/src/universal/decorators/meatierForm/meatierForm.js
+++ b/src/universal/decorators/meatierForm/meatierForm.js
@@ -1,0 +1,22 @@
+import {reduxForm} from 'redux-form';
+import Joi from 'joi';
+import {parsedJoiErrors} from 'universal/utils/schema';
+import {getFormState} from 'universal/redux/helpers';
+
+/**
+ * A small wrapper for reduxForm that can (optionally) inject a validate method based on the Joi `schema` prop in the
+ * options, and also injects the necessary `getFormState` for `redux-optimistic-ui`.
+ */
+export default function meatierForm(options) {
+  const {schema} = options
+  return reduxForm(Object.assign(
+    options,
+    {getFormState},
+    schema && {
+      validate(values) {
+        const results = Joi.validate(values, options.schema, {abortEarly: false});
+        return parsedJoiErrors(results.error);
+      }
+    }
+  ));
+}

--- a/src/universal/modules/auth/components/LostPassword/LostPassword.js
+++ b/src/universal/modules/auth/components/LostPassword/LostPassword.js
@@ -2,14 +2,11 @@ import React, {PropTypes, Component} from 'react';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 import styles from './LostPassword.css';
-import {reduxForm} from 'redux-form';
-import Joi from 'joi';
+import meatierForm from 'universal/decorators/meatierForm/meatierForm'
 import {emailPasswordReset} from '../../ducks/auth';
 import {authSchemaEmail} from '../../schemas/auth';
-import {parsedJoiErrors} from 'universal/utils/schema';
-import {getFormState} from 'universal/redux/helpers';
 
-@reduxForm({form: 'lostPasswordForm', fields: ['email'], validate, getFormState})
+@meatierForm({form: 'lostPasswordForm', fields: ['email'], schema: authSchemaEmail})
 export default class LostPassword extends Component {
   static propTypes = {
     fields: PropTypes.object,
@@ -58,9 +55,4 @@ export default class LostPassword extends Component {
       </div>
     );
   }
-}
-
-function validate(values) {
-  const results = Joi.validate(values, authSchemaEmail, {abortEarly: false});
-  return parsedJoiErrors(results.error);
 }

--- a/src/universal/modules/auth/components/ResetPassword/ResetPassword.js
+++ b/src/universal/modules/auth/components/ResetPassword/ResetPassword.js
@@ -2,14 +2,11 @@ import React, {PropTypes, Component} from 'react';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 import styles from './ResetPassword.css';
-import {reduxForm} from 'redux-form';
-import Joi from 'joi';
+import meatierForm from 'universal/decorators/meatierForm/meatierForm'
 import {authSchemaPassword} from '../../schemas/auth';
 import {resetPassword} from '../../ducks/auth';
-import {parsedJoiErrors} from 'universal/utils/schema';
-import {getFormState} from 'universal/redux/helpers';
 
-@reduxForm({form: 'resetPasswordForm', fields: ['password'], validate, getFormState})
+@meatierForm({form: 'resetPasswordForm', fields: ['password'], schema: authSchemaPassword})
 export default class ResetPassword extends Component {
   static propTypes = {
     fields: PropTypes.any,
@@ -56,9 +53,4 @@ export default class ResetPassword extends Component {
     const outData = Object.assign({}, data, {resetToken});
     return resetPassword(outData, dispatch);
   };
-}
-
-function validate(values) {
-  const results = Joi.validate(values, authSchemaPassword, {abortEarly: false});
-  return parsedJoiErrors(results.error);
 }

--- a/src/universal/modules/auth/containers/Auth/AuthContainer.js
+++ b/src/universal/modules/auth/containers/Auth/AuthContainer.js
@@ -2,16 +2,13 @@ import React, {Component, PropTypes} from 'react';
 import {authSchemaInsert} from '../../schemas/auth';
 import {connect} from 'react-redux';
 import Auth from '../../components/Auth/Auth';
-import {reduxForm} from 'redux-form';
-import Joi from 'joi';
-import {parsedJoiErrors} from 'universal/utils/schema';
-import {getFormState} from 'universal/redux/helpers';
 import {ensureState} from 'redux-optimistic-ui';
+import meatierForm from 'universal/decorators/meatierForm/meatierForm'
 
 // use the same form to retain form values (there's really no difference between login and signup, it's just for show)
 @connect(mapStateToProps)
 // must come after connect to get the path field
-@reduxForm({form: 'authForm', fields: ['email', 'password'], validate, getFormState})
+@meatierForm({form: 'authForm', fields: ['email', 'password'], schema: authSchemaInsert})
 export default class AuthContainer extends Component {
   static propTypes = {
     location: PropTypes.object,
@@ -42,9 +39,3 @@ function mapStateToProps(state, props) {
     pathname: props.location.pathname
   };
 }
-
-function validate(values) {
-  const results = Joi.validate(values, authSchemaInsert, {abortEarly: false});
-  return parsedJoiErrors(results.error);
-}
-


### PR DESCRIPTION
This just wraps up the basic pattern you're using with `reduxForm`, it provides the `getFormState` and `validate` based on the Joi `schema` passed in.  It should be useful for anyone making more forms based upon this pattern.

For instance `AuthContainer` now looks like:

```js
@meatierForm({form: 'authForm', fields: ['email', 'password'], schema: authSchemaInsert})
export default class AuthContainer extends Component {
 ```