### PR TITLE
restore proper display of form field errors from GraphQL requests

### DIFF
--- a/src/server/graphql/httpGraphQLHandler.js
+++ b/src/server/graphql/httpGraphQLHandler.js
@@ -1,14 +1,13 @@
 import Schema from './rootSchema';
 import {graphql} from 'graphql';
+import {prepareClientError} from './models/utils';
 
 export default async (req, res) => {
   // Check for admin privileges
   const {query, variables, ...newContext} = req.body;
   const authToken = req.user || {};
   const context = {authToken, ...newContext};
-  const result = await graphql(Schema, query, null, context, variables);
-  if (result.errors) {
-    console.log('DEBUG GraphQL Error:', result.errors);
-  }
-  res.send(result);
+  const result = await graphql(Schema, query, null, context, variables)
+  const {error} = prepareClientError(result)
+  res.send({data: result.data, error})
 };

--- a/src/server/graphql/httpGraphQLHandler.js
+++ b/src/server/graphql/httpGraphQLHandler.js
@@ -5,7 +5,7 @@ export default async (req, res) => {
   // Check for admin privileges
   const {query, variables, ...newContext} = req.body;
   const authToken = req.user || {};
-  const context = {authToken, context: newContext};
+  const context = {authToken, ...newContext};
   const result = await graphql(Schema, query, null, context, variables);
   if (result.errors) {
     console.log('DEBUG GraphQL Error:', result.errors);

--- a/src/universal/utils/fetching.js
+++ b/src/universal/utils/fetching.js
@@ -32,11 +32,7 @@ export function getJSON(route) {
 //  return Object.assign({}, ...(for (p of fields) {[p]: o[p]}));
 // }
 
-export const getClientError = errors => {
-  if (!errors) {
-    return;
-  }
-  const error = errors[0].message;
+export const getClientError = error => {
   if (!error || error.indexOf('{"_error"') === -1) {
     return {_error: 'Server query error'};
   }
@@ -63,6 +59,6 @@ export const fetchGraphQL = async graphParams => {
     body: serializedParams
   });
   const resJSON = await res.json();
-  const {data, errors} = resJSON;
-  return {data, error: getClientError(errors)};
+  const {data, error} = resJSON;
+  return {data, error: getClientError(error)};
 };


### PR DESCRIPTION
Seems something must have caused a regression of displaying form errors from GraphQL (I'll open an issue in a moment).  This PR restores proper error display by ensuring errors get delivered and processed on the client in the way that seems originally intended.