### PR TITLE
pass server values of PROTOCOL, HOST, and PORT to client at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "file-loader": "0.8.5",
     "happypack": "2.1.0",
     "json-loader": "0.5.4",
+    "node-libs-browser": "1.0.0",
     "null-loader": "0.1.1",
     "postcss-loader": "0.9.1",
     "postcss-modules-values": "1.1.2",

--- a/src/client/process.js
+++ b/src/client/process.js
@@ -1,0 +1,5 @@
+import libs from 'node-libs-browser';
+// libs exports a map of module numbers, not the modules themselves
+const process = __webpack_require__(libs.process);
+// overwrite env with variables that have been provided from a SSR script
+export default {...process, env: window.__env__}

--- a/src/client/process.js
+++ b/src/client/process.js
@@ -1,5 +1,7 @@
 import libs from 'node-libs-browser';
 // libs exports a map of module numbers, not the modules themselves
+/* eslint-disable no-undef */
 const process = __webpack_require__(libs.process);
+/* eslint-enable no-undef */
 // overwrite env with variables that have been provided from a SSR script
-export default {...process, env: window.__env__}
+export default {...process, env: window.__env__};

--- a/src/server/Html.js
+++ b/src/server/Html.js
@@ -10,6 +10,7 @@ export default class Html extends Component {
     store: PropTypes.object.isRequired,
     title: PropTypes.string.isRequired,
     assets: PropTypes.object,
+    env: PropTypes.object,
     renderProps: PropTypes.object
   }
 
@@ -18,6 +19,7 @@ export default class Html extends Component {
     const {title, store, assets, renderProps} = this.props;
     const {manifest, app, vendor} = assets || {};
     const initialState = `window.__INITIAL_STATE__ = ${JSON.stringify(store.getState())}`;
+    const env = `window.__env__ = ${JSON.stringify(this.props.env)}`;
     const root = PROD && renderToString(
       <Provider store={store}>
         <RouterContext {...renderProps}/>
@@ -30,6 +32,7 @@ export default class Html extends Component {
           <title>{title}</title>
         </head>
         <body>
+          <script dangerouslySetInnerHTML={{__html: env}}/>
           <script dangerouslySetInnerHTML={{__html: initialState}}/>
           {PROD ? <div id="root" dangerouslySetInnerHTML={{__html: root}}></div> : <div id="root"></div>}
           {PROD && <script dangerouslySetInnerHTML={{__html: manifest.text}}/>}

--- a/src/server/clientEnv.js
+++ b/src/server/clientEnv.js
@@ -1,0 +1,2 @@
+const {PROTOCOL, HOST, PORT} = process.env;
+export default {PROTOCOL, HOST, PORT};

--- a/src/server/createSSR.js
+++ b/src/server/createSSR.js
@@ -10,6 +10,7 @@ import {join, basename} from 'path';
 import promisify from 'es6-promisify';
 import thunkMiddleware from 'redux-thunk';
 import {Map as iMap} from 'immutable';
+import clientEnv from './clientEnv';
 
 // https://github.com/systemjs/systemjs/issues/953
 
@@ -21,6 +22,7 @@ function renderApp(res, store, assets, renderProps) {
     title="meatier"
     store={store}
     assets={assets}
+    env={clientEnv}
     renderProps={renderProps}
     />);
   res.write('<!DOCTYPE html>');

--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -65,11 +65,10 @@ export default {
       '__PRODUCTION__': false,
       'process.env.NODE_ENV': JSON.stringify('development')
     }),
-    new webpack.EnvironmentPlugin([
-      'PROTOCOL',
-      'HOST',
-      'PORT'
-    ]),
+    new webpack.ProvidePlugin({
+      // inject certain process.env variables provided by the server
+      process: 'client/process.js' 
+    }),
     new HappyPack({
       loaders: ['babel'],
       threads: 4
@@ -79,10 +78,12 @@ export default {
     extensions: ['.js'],
     modules: [srcDir, 'node_modules']
   },
-  // used for joi validation on client
   node: {
+    // used for joi validation on client
     dns: 'mock',
-    net: 'mock'
+    net: 'mock',
+    // we're controlling the process polyfill with environment variables passed from the server
+    process: false,
   },
   postcss: [cssModulesValues],
   module: {

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -58,14 +58,15 @@ export default {
   },
   node: {
     dns: 'mock',
-    net: 'mock'
+    net: 'mock',
+    process: false,
   },
   postcss: [cssModulesValues],
   plugins: [
     ...prefetchPlugins,
     new webpack.NamedModulesPlugin(),
     new webpack.optimize.CommonsChunkPlugin({
-      names: ['vendor', 'manifest'],
+      names: ['client/process.js', 'vendor', 'manifest'],
       minChunks: Infinity
     }),
     new webpack.optimize.AggressiveMergingPlugin(),
@@ -78,11 +79,10 @@ export default {
       '__PRODUCTION__': true,
       'process.env.NODE_ENV': JSON.stringify('production')
     }),
-    new webpack.EnvironmentPlugin([
-      'PROTOCOL',
-      'HOST',
-      'PORT'
-    ]),
+    new webpack.ProvidePlugin({
+      // inject certain process.env variables provided by the server
+      process: 'client/process.js'
+    }),
     new HappyPack({
       loaders: ['babel'],
       threads: 4


### PR DESCRIPTION
Fixes https://github.com/mattkrick/meatier/issues/164.

How it works:

* SSR injects this script at the top of the body with values from server's `process.env` (see `clientEnv.js`):
```html
<script>window.__env__ = {PROTOCOL: ..., HOST: ..., PORT: ...}</script>
```
* `client/process.js` gets the `process` polyfill that webpack normally uses and adds the environment variables from `window.__env__` to it
* Webpack configs use `ProvidePlugin` to replace all references to `process` on the client side with (esentially) `require('client/process.js')`
* Note: I put `client/process.js` in the commons chunk since some of the vendor deps refer to `process`.

#### TODO
* [ ] double check that this doesn't stomp on `process.env.NODE_ENV` defines.