### PR TITLE
use window.location instead of environment vars to build hostUrl

### DIFF
--- a/src/universal/utils/fetching.js
+++ b/src/universal/utils/fetching.js
@@ -6,10 +6,11 @@ export function parseJSON(response) {
 }
 
 export function hostUrl() {
-  const host = process.env.HOST;
-  const protocol = process.env.PROTOCOL;
-  const port = process.env.PORT;
-  return `${protocol}://${host}:${port}`;
+  if (typeof window !== 'undefined' && window.location) {
+    const {origin, protocol, host} = window.location; 
+    return origin || `${protocol}//${host}`;
+  }
+  return 'http://localhost:3000';
 }
 
 export function postJSON(route, obj) {

--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -65,11 +65,6 @@ export default {
       '__PRODUCTION__': false,
       'process.env.NODE_ENV': JSON.stringify('development')
     }),
-    new webpack.EnvironmentPlugin([
-      'PROTOCOL',
-      'HOST',
-      'PORT'
-    ]),
     new HappyPack({
       loaders: ['babel'],
       threads: 4

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -78,11 +78,6 @@ export default {
       '__PRODUCTION__': true,
       'process.env.NODE_ENV': JSON.stringify('production')
     }),
-    new webpack.EnvironmentPlugin([
-      'PROTOCOL',
-      'HOST',
-      'PORT'
-    ]),
     new HappyPack({
       loaders: ['babel'],
       threads: 4


### PR DESCRIPTION
As you suggested

No need to use `webpack.EnvironmentPlugin` anymore