### PR TITLE
Fixed a typo and added a tip regarding devtools switching

### DIFF
--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -37,7 +37,11 @@ const babelQuery = {
 };
 
 export default {
-  // devtool: 'source-maps',
+  // devtool: 'source-map',
+  /*
+   When changing developer tool for debugging,
+   be sure to clear happypack cache (rm -r .happypack/) to clear out old source-maps
+  */
   devtool: 'eval',
   context: srcDir,
   entry: {


### PR DESCRIPTION
Hi!
Not sure that a PR with just changing comments is a right thing to do, and I'm sorry if it isn't,  but I've spent some time because of uncommenting this line `// devtool: 'source-maps'` with a typo.  [Should be](http://webpack.github.io/docs/configuration.html#devtool) `devtool: 'source-map' ` . I hope my small changes can save others time :) 

Also, added a tip about clearing happypack cache, when changing `devtools` option. 